### PR TITLE
Remove uneeded libphobos from Arch instructions

### DIFF
--- a/doc/setup/volta.md
+++ b/doc/setup/volta.md
@@ -22,7 +22,7 @@ Building Volt requires a D compiler as well as llvm:
     $ sudo apt-get install dmd llvm
 
     # Arch Linux
-    $ sudo pacman -S dmd libphobos llvm
+    $ sudo pacman -S dmd llvm
 
 
 Instead of using the packaged DMD binaries on Ubuntu or Debian you can use the


### PR DESCRIPTION
Default static linking is used for which plain `dmd` is enough.
`libphobos` package provides shared `libphobos2.so` library and
is not required here.
